### PR TITLE
Broke some windows builds. Bring back doFmtVerbLevelColor

### DIFF
--- a/log_nix.go
+++ b/log_nix.go
@@ -13,23 +13,6 @@ import (
 	"log"
 )
 
-// TODO initialize here
-var colors []string
-var boldcolors []string
-
-type color int
-
-const (
-	colorBlack = iota + 30
-	colorRed
-	colorGreen
-	colorYellow
-	colorBlue
-	colorMagenta
-	colorCyan
-	colorWhite
-)
-
 // LogBackend utilizes the standard log module.
 type LogBackend struct {
 	Logger *log.Logger
@@ -56,37 +39,7 @@ func (b *LogBackend) Log(level Level, calldepth int, rec *Record) error {
 	return b.Logger.Output(calldepth+2, rec.Formatted(calldepth+1))
 }
 
-func colorSeq(color color) string {
-	return fmt.Sprintf("\033[%dm", int(color))
-}
-
-func colorSeqBold(color color) string {
-	return fmt.Sprintf("\033[%d;1m", int(color))
-}
 
 func init() {
-	colors = []string{
-		CRITICAL: colorSeq(colorMagenta),
-		ERROR:    colorSeq(colorRed),
-		WARNING:  colorSeq(colorYellow),
-		NOTICE:   colorSeq(colorGreen),
-		DEBUG:    colorSeq(colorCyan),
-	}
-	boldcolors = []string{
-		CRITICAL: colorSeqBold(colorMagenta),
-		ERROR:    colorSeqBold(colorRed),
-		WARNING:  colorSeqBold(colorYellow),
-		NOTICE:   colorSeqBold(colorGreen),
-		DEBUG:    colorSeqBold(colorCyan),
-	}
-}
-
-func doFmtVerbLevelColor(layout string, level Level, output io.Writer) {
-	if layout == "bold" {
-		output.Write([]byte(boldcolors[level]))
-	} else if layout == "reset" {
-		output.Write([]byte("\033[0m"))
-	} else {
-		output.Write([]byte(colors[level]))
-	}
+	init_colors()
 }


### PR DESCRIPTION
I [broke some builds](https://github.com/op/go-logging/issues/69#issuecomment-162080282) for people using go-logging; this should fix that. Also brings back doFmtVerbLevelColor, which we can now support. 

I was wondering, though, whether the ansi color translator belongs in here? not sure anyone would want it.

@maxtaco 
