### PR TITLE
Zanderz/colors 2015.12.04

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -27,7 +27,8 @@ func main() {
 	// For demo purposes, create two backend for os.Stderr.
 	backend1 := logging.NewLogBackend(os.Stderr, "", 0)
 	backend2 := logging.NewLogBackend(os.Stderr, "", 0)
-
+	backend1.Color = true
+	backend2.Color = true
 	// For messages written to backend2 we want to add some additional
 	// information to the output, including the used log level and the name of
 	// the function.

--- a/format.go
+++ b/format.go
@@ -175,6 +175,9 @@ type stringFormatter struct {
 // "%{color:bold}%{time:15:04:05} %{level:-8s}%{color:reset} %{message}" will
 // just colorize the time and level, leaving the message uncolored.
 //
+// Colors on Windows is unfortunately not supported right now and is currently
+// a no-op.
+//
 // There's also a couple of experimental 'verbs'. These are exposed to get
 // feedback and needs a bit of tinkering. Hence, they might change in the
 // future.

--- a/log.go
+++ b/log.go
@@ -1,0 +1,59 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logging
+
+import (
+	"fmt"
+	"io"
+)
+
+type color int
+
+const (
+	colorBlack = iota + 30
+	colorRed
+	colorGreen
+	colorYellow
+	colorBlue
+	colorMagenta
+	colorCyan
+	colorWhite
+)
+
+var (
+	colors = []string{
+		CRITICAL: colorSeq(colorMagenta),
+		ERROR:    colorSeq(colorRed),
+		WARNING:  colorSeq(colorYellow),
+		NOTICE:   colorSeq(colorGreen),
+		DEBUG:    colorSeq(colorCyan),
+	}
+	boldcolors = []string{
+		CRITICAL: colorSeqBold(colorMagenta),
+		ERROR:    colorSeqBold(colorRed),
+		WARNING:  colorSeqBold(colorYellow),
+		NOTICE:   colorSeqBold(colorGreen),
+		DEBUG:    colorSeqBold(colorCyan),
+	}
+)
+
+func colorSeq(color color) string {
+	return fmt.Sprintf("\033[%dm", int(color))
+}
+
+func colorSeqBold(color color) string {
+	return fmt.Sprintf("\033[%d;1m", int(color))
+}
+
+func doFmtVerbLevelColor(layout string, level Level, output io.Writer) {
+	if layout == "bold" {
+		output.Write([]byte(boldcolors[level]))
+	} else if layout == "reset" {
+		output.Write([]byte("\033[0m"))
+	} else {
+		output.Write([]byte(colors[level]))
+	}
+}
+

--- a/log_nix.go
+++ b/log_nix.go
@@ -8,39 +8,8 @@ package logging
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"log"
-)
-
-type color int
-
-const (
-	colorBlack = iota + 30
-	colorRed
-	colorGreen
-	colorYellow
-	colorBlue
-	colorMagenta
-	colorCyan
-	colorWhite
-)
-
-var (
-	colors = []string{
-		CRITICAL: colorSeq(colorMagenta),
-		ERROR:    colorSeq(colorRed),
-		WARNING:  colorSeq(colorYellow),
-		NOTICE:   colorSeq(colorGreen),
-		DEBUG:    colorSeq(colorCyan),
-	}
-	boldcolors = []string{
-		CRITICAL: colorSeqBold(colorMagenta),
-		ERROR:    colorSeqBold(colorRed),
-		WARNING:  colorSeqBold(colorYellow),
-		NOTICE:   colorSeqBold(colorGreen),
-		DEBUG:    colorSeqBold(colorCyan),
-	}
 )
 
 // LogBackend utilizes the standard log module.
@@ -69,20 +38,3 @@ func (b *LogBackend) Log(level Level, calldepth int, rec *Record) error {
 	return b.Logger.Output(calldepth+2, rec.Formatted(calldepth+1))
 }
 
-func colorSeq(color color) string {
-	return fmt.Sprintf("\033[%dm", int(color))
-}
-
-func colorSeqBold(color color) string {
-	return fmt.Sprintf("\033[%d;1m", int(color))
-}
-
-func doFmtVerbLevelColor(layout string, level Level, output io.Writer) {
-	if layout == "bold" {
-		output.Write([]byte(boldcolors[level]))
-	} else if layout == "reset" {
-		output.Write([]byte("\033[0m"))
-	} else {
-		output.Write([]byte(colors[level]))
-	}
-}

--- a/log_nix.go
+++ b/log_nix.go
@@ -13,10 +13,6 @@ import (
 	"log"
 )
 
-// TODO initialize here
-var colors []string
-var boldcolors []string
-
 type color int
 
 const (
@@ -28,6 +24,23 @@ const (
 	colorMagenta
 	colorCyan
 	colorWhite
+)
+
+var (
+	colors = []string{
+		CRITICAL: colorSeq(colorMagenta),
+		ERROR:    colorSeq(colorRed),
+		WARNING:  colorSeq(colorYellow),
+		NOTICE:   colorSeq(colorGreen),
+		DEBUG:    colorSeq(colorCyan),
+	}
+	boldcolors = []string{
+		CRITICAL: colorSeqBold(colorMagenta),
+		ERROR:    colorSeqBold(colorRed),
+		WARNING:  colorSeqBold(colorYellow),
+		NOTICE:   colorSeqBold(colorGreen),
+		DEBUG:    colorSeqBold(colorCyan),
+	}
 )
 
 // LogBackend utilizes the standard log module.
@@ -62,23 +75,6 @@ func colorSeq(color color) string {
 
 func colorSeqBold(color color) string {
 	return fmt.Sprintf("\033[%d;1m", int(color))
-}
-
-func init() {
-	colors = []string{
-		CRITICAL: colorSeq(colorMagenta),
-		ERROR:    colorSeq(colorRed),
-		WARNING:  colorSeq(colorYellow),
-		NOTICE:   colorSeq(colorGreen),
-		DEBUG:    colorSeq(colorCyan),
-	}
-	boldcolors = []string{
-		CRITICAL: colorSeqBold(colorMagenta),
-		ERROR:    colorSeqBold(colorRed),
-		WARNING:  colorSeqBold(colorYellow),
-		NOTICE:   colorSeqBold(colorGreen),
-		DEBUG:    colorSeqBold(colorCyan),
-	}
 }
 
 func doFmtVerbLevelColor(layout string, level Level, output io.Writer) {

--- a/log_windows.go
+++ b/log_windows.go
@@ -18,10 +18,6 @@ var (
 	setConsoleTextAttributeProc = kernel32DLL.NewProc("SetConsoleTextAttribute")
 )
 
-// TODO initialize here
-var colors []WORD
-var boldcolors []WORD
-
 type color int
 type WORD uint16
 
@@ -41,6 +37,25 @@ const (
 	fgWhite     WORD = 0x0007
 	fgIntensity WORD = 0x0008
 	fgMask      WORD = 0x000F
+)
+
+var (
+	colors = []word{
+		INFO:     fgWhite,
+		CRITICAL: fgMagenta,
+		ERROR:    fgRed,
+		WARNING:  fgYellow,
+		NOTICE:   fgGreen,
+		DEBUG:    fgCyan,
+	}
+	boldcolors = []word{
+		INFO:     fgWhite | fgIntensity,
+		CRITICAL: fgMagenta | fgIntensity,
+		ERROR:    fgRed | fgIntensity,
+		WARNING:  fgYellow | fgIntensity,
+		NOTICE:   fgGreen | fgIntensity,
+		DEBUG:    fgCyan | fgIntensity,
+	}
 )
 
 // LogBackend utilizes the standard log module.
@@ -67,25 +82,6 @@ func (b *LogBackend) Log(level Level, calldepth int, rec *Record) error {
 		return err
 	}
 	return b.Logger.Output(calldepth+2, rec.Formatted(calldepth+1))
-}
-
-func init() {
-	colors = []WORD{
-		INFO:     fgWhite,
-		CRITICAL: fgMagenta,
-		ERROR:    fgRed,
-		WARNING:  fgYellow,
-		NOTICE:   fgGreen,
-		DEBUG:    fgCyan,
-	}
-	boldcolors = []WORD{
-		INFO:     fgWhite | fgIntensity,
-		CRITICAL: fgMagenta | fgIntensity,
-		ERROR:    fgRed | fgIntensity,
-		WARNING:  fgYellow | fgIntensity,
-		NOTICE:   fgGreen | fgIntensity,
-		DEBUG:    fgCyan | fgIntensity,
-	}
 }
 
 // setConsoleTextAttribute sets the attributes of characters written to the

--- a/log_windows.go
+++ b/log_windows.go
@@ -17,6 +17,8 @@ var (
 	setConsoleTextAttributeProc = kernel32DLL.NewProc("SetConsoleTextAttribute")
 )
 
+type WORD uint16
+
 // Character attributes
 // Note:
 // -- The attributes are combined to produce various colors (e.g., Blue + Green will create Cyan).
@@ -36,7 +38,7 @@ const (
 )
 
 var (
-	colors = []uint16{
+	win_colors = []uint16{
 		INFO:     fgWhite,
 		CRITICAL: fgMagenta,
 		ERROR:    fgRed,
@@ -44,7 +46,7 @@ var (
 		NOTICE:   fgGreen,
 		DEBUG:    fgCyan,
 	}
-	boldcolors = []uint16{
+	win_boldcolors = []uint16{
 		INFO:     fgWhite | fgIntensity,
 		CRITICAL: fgMagenta | fgIntensity,
 		ERROR:    fgRed | fgIntensity,
@@ -84,7 +86,7 @@ func NewLogBackend(out io.Writer, prefix string, flag int) *LogBackend {
 func (b *LogBackend) Log(level Level, calldepth int, rec *Record) error {
 	if b.Color && b.f != nil {
 		buf := &bytes.Buffer{}
-		setConsoleTextAttribute(b.f, colors[level])
+		setConsoleTextAttribute(b.f, win_colors[level])
 		buf.Write([]byte(rec.Formatted(calldepth + 1)))
 		err := b.Logger.Output(calldepth+2, buf.String())
 		setConsoleTextAttribute(b.f, fgWhite)
@@ -92,6 +94,7 @@ func (b *LogBackend) Log(level Level, calldepth int, rec *Record) error {
 	}
 	return b.Logger.Output(calldepth+2, rec.Formatted(calldepth+1))
 }
+
 
 // setConsoleTextAttribute sets the attributes of characters written to the
 // console screen buffer by the WriteFile or WriteConsole function.
@@ -101,7 +104,3 @@ func setConsoleTextAttribute(f file, attribute uint16) bool {
 	return ok != 0
 }
 
-func doFmtVerbLevelColor(layout string, level Level, output io.Writer) {
-	// TODO not supported on Windows since the io.Writer here is actually a
-	// bytes.Buffer.
-}

--- a/log_windows.go
+++ b/log_windows.go
@@ -102,4 +102,6 @@ func setConsoleTextAttribute(f file, attribute uint16) bool {
 }
 
 func doFmtVerbLevelColor(layout string, level Level, output io.Writer) {
+	// TODO not supported on Windows since the io.Writer here is actually a
+	// bytes.Buffer.
 }


### PR DESCRIPTION
Seemed easiest to use our new color writer to make logging consistent.
I had to merge in some other changes from go-logging that were caused by my previous PR [breaking some windows builds](https://github.com/op/go-logging/issues/69#issuecomment-162080282). I will make a PR to op/go-logging after this one is reviewed. @maxtaco 
