### PR TITLE
Revert "Fixes missing Criticalf method"

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -206,11 +206,6 @@ func (l *Logger) Criticalf(format string, args ...interface{}) {
 	l.log(CRITICAL, &format, args...)
 }
 
-// Criticalf logs a message using CRITICAL as log level.
-func (l *Logger) Criticalf(format string, args ...interface{}) {
-	l.log(CRITICAL, format, args...)
-}
-
 // Error logs a message using ERROR as log level.
 func (l *Logger) Error(args ...interface{}) {
 	l.log(ERROR, nil, args...)


### PR DESCRIPTION
Reverts keybase/go-logging#6

I saw this cause I forgot to `go get -u` oops.. nm
